### PR TITLE
ci: fix cwd at NPM publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           commit: 'chore: bump package version'
           version: node .github/changeset-version.js
           publish: pnpm run release
+          cwd: './lib'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes npm publish getting the wrong dist folder, using cwd input based on own action doc: https://github.com/changesets/action